### PR TITLE
Fix otherButtonTitle getting added twice

### DIFF
--- a/WSLViewAutoDismiss/WSLViewAutoDismiss/WSLAlertViewAutoDismiss.m
+++ b/WSLViewAutoDismiss/WSLViewAutoDismiss/WSLAlertViewAutoDismiss.m
@@ -26,7 +26,7 @@
 }
 
 - (id)initWithTitle:(NSString *)title message:(NSString *)message delegate:(id)delegate cancelButtonTitle:(NSString *)cancelButtonTitle otherButtonTitles:(NSString *)otherButtonTitles, ... {
-    self = [super initWithTitle:title message:message delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:otherButtonTitles, nil];
+    self = [super initWithTitle:title message:message delegate:delegate cancelButtonTitle:cancelButtonTitle otherButtonTitles:nil];
     if (self) {
         if (otherButtonTitles) {
             va_list args;


### PR DESCRIPTION
Fixes the difference between block and non-block versions such that the first otherButtonTitles is only added once
